### PR TITLE
simplify font-family

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <style>
     body {
       background: #FFF url('bg.gif') 0 0 repeat-x;
-      font-family: "Century Gothic", CenturyGothic, AppleGothic, sans-serif;
+      font-family: sans-serif;
     }
     h1, h2 {
       color: #00B2F2;


### PR DESCRIPTION
Na Macu ten font sice existuje, ale nemá diakritiku, takže je ošklivý. Nestačil by `sans-serif`? 

Takhle to vidím u sebe v původní podobě:

![screen shot 2015-04-16 at 17 14 23](https://cloud.githubusercontent.com/assets/156676/7184210/43260b3c-e45c-11e4-8d98-ff5560b07dc6.png)
